### PR TITLE
Fix for large file uploads on https

### DIFF
--- a/include/http/libcurl_http_client.h
+++ b/include/http/libcurl_http_client.h
@@ -294,7 +294,7 @@ namespace azure {  namespace storage_lite {
         }
 
         //Sets CURL CA BUNDLE location for all the curl handlers.
-        CurlEasyClient(int size, const std::string& ca_path) : m_size(size)
+        CurlEasyClient(int size, const std::string& ca_path) : m_size(size), m_caPath(ca_path)
         {
             curl_global_init(CURL_GLOBAL_DEFAULT);
             for (int i = 0; i < m_size; i++) {
@@ -327,6 +327,11 @@ namespace azure {  namespace storage_lite {
             return res;
         }
 
+	 std::string getCaPath(void)
+	 {
+	     return m_caPath;
+	 }
+
         void release_handle(CURL *h)
         {
             std::lock_guard<std::mutex> lg(m_handles_mutex);
@@ -336,6 +341,7 @@ namespace azure {  namespace storage_lite {
 
     private:
         int m_size;
+        std::string m_caPath;
         std::queue<CURL *> m_handles;
         std::mutex m_handles_mutex;
         std::condition_variable m_cv;

--- a/src/http/libcurl_http_client.cpp
+++ b/src/http/libcurl_http_client.cpp
@@ -13,6 +13,8 @@ namespace azure {  namespace storage_lite {
         {
             check_code(curl_easy_setopt(m_curl, CURLOPT_HEADERFUNCTION, header_callback));
             check_code(curl_easy_setopt(m_curl, CURLOPT_HEADERDATA, this));
+            std::string capath = m_client->getCaPath();
+            check_code(curl_easy_setopt(m_curl, CURLOPT_CAINFO, capath.c_str()));
         }
 
         CurlEasyRequest::~CurlEasyRequest()


### PR DESCRIPTION
When uploading large files new curl handles are not set with capath which causes CURLE_PEER_FAILED_VERIFICATION. 